### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/atmz/65195e0e-4458-4ef5-8c66-bfd11df6a1ab/07bc3777-ad0a-4bd3-b3a8-3fe8fdb77ef8/_apis/work/boardbadge/bcde05ee-7596-43d2-8b28-2175944974c4)](https://dev.azure.com/atmz/65195e0e-4458-4ef5-8c66-bfd11df6a1ab/_boards/board/t/07bc3777-ad0a-4bd3-b3a8-3fe8fdb77ef8/Microsoft.RequirementCategory)
 # test-jenkins-01


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/atmz/65195e0e-4458-4ef5-8c66-bfd11df6a1ab/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.